### PR TITLE
Fix storage loading

### DIFF
--- a/basicBot.js
+++ b/basicBot.js
@@ -188,6 +188,7 @@
         chat: null,
         loadChat: loadChat,
         retrieveSettings: retrieveSettings,
+        retrieveFromStorage: retrieveFromStorage,
         settings: {
             botName: "basicBot",
             language: "english",


### PR DESCRIPTION
retrieveFromStorage wasn't actually assigned to the basicBot object, which causes the function to never run, and it's settings to never be loaded. This fixes the issue.
